### PR TITLE
Refactor library to be .NET Standard 2.1 for maximum compatibility.

### DIFF
--- a/NovelAPI.cs
+++ b/NovelAPI.cs
@@ -7,6 +7,10 @@ using Newtonsoft.Json;
 using static net.novelai.api.Structs;
 using System.Text.Json.Nodes;
 using novelai.util;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+using System.Linq;
 
 namespace net.novelai.api
 {

--- a/NovelAPI.csproj
+++ b/NovelAPI.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/authentication/Auth.cs
+++ b/authentication/Auth.cs
@@ -1,6 +1,11 @@
 ﻿using Konscious.Security.Cryptography;
 using net.novelai.api;
 using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+
 //using System;
 //using System.Collections.Generic;
 //using System.IO;

--- a/generation/Scenario.cs
+++ b/generation/Scenario.cs
@@ -1,5 +1,8 @@
 ﻿using net.novelai.api;
 using net.novelai.util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using static net.novelai.api.Structs;
 

--- a/util/GPTEncoder.cs
+++ b/util/GPTEncoder.cs
@@ -1,6 +1,10 @@
 ﻿using System.Text.Json;
 using net.novelai.api;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System;
 
 namespace net.novelai.util
 {

--- a/util/KayraEncoder.cs
+++ b/util/KayraEncoder.cs
@@ -5,6 +5,9 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using net.novelai.util;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace novelai.util
 {


### PR DESCRIPTION
Since there might be an issue with updating the API to .NET 8 for some projects, This is an attempt to refactor the library to be .NET Standard 2.1 compatible. This does require that all using statements must now be explicitly declared at the top of each file. It may be necessary to do a full clean and rebuild of the solution, but should make the library compatible with most projects.